### PR TITLE
Make Dilla Xhon default deck and remove some Don Miguel cards

### DIFF
--- a/src/Loteria/barajas.js
+++ b/src/Loteria/barajas.js
@@ -1,286 +1,8 @@
 export const barajas = {
-  es01: {
-    nombre: "español de MX",
-    botones: {
-      ganar: "¡lotería!",
-    },
-    cartas: {
-      "01": {
-        nombre: "el gallo",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/01-gallo.jpg",
-        audio: "",
-      },
-      "02": {
-        nombre: "el diablito",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/02-diablito.jpg",
-        audio: "",
-      },
-      "03": {
-        nombre: "la dama",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/03-dama.jpg",
-        audio: "",
-      },
-      "04": {
-        nombre: "el catrín",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/04-catrin.jpg",
-        audio: "",
-      },
-      "05": {
-        nombre: "el paraguas",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/05-paraguas.jpg",
-        audio: "",
-      },
-      "06": {
-        nombre: "la sirena",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/06-sirena.jpg",
-        audio: "",
-      },
-      "07": {
-        nombre: "la escalera",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/07-escalera.jpg",
-        audio: "",
-      },
-      "08": {
-        nombre: "la botella",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/08-botella.jpg",
-        audio: "",
-      },
-      "09": {
-        nombre: "el barril",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/09-barril.jpg",
-        audio: "",
-      },
-      10: {
-        nombre: "el árbol",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/10-arbol.jpg",
-        audio: "",
-      },
-      11: {
-        nombre: "el melón",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/11-melon.jpg",
-        audio: "",
-      },
-      12: {
-        nombre: "el valiente",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/12-valiente.jpg",
-        audio: "",
-      },
-      13: {
-        nombre: "el gorrito",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/13-gorrito.jpg",
-        audio: "",
-      },
-      14: {
-        nombre: "la muerte",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/14-muerte.jpg",
-        audio: "",
-      },
-      15: {
-        nombre: "la pera",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/15-pera.jpg",
-        audio: "",
-      },
-      16: {
-        nombre: "la bandera",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/16-bandera.jpg",
-        audio: "",
-      },
-      17: {
-        nombre: "el bandolón",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/17-bandolon.jpg",
-        audio: "",
-      },
-      18: {
-        nombre: "el violoncello",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/18-violoncello.jpg",
-        audio: "",
-      },
-      19: {
-        nombre: "la garza",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/19-garza.jpg",
-        audio: "",
-      },
-      20: {
-        nombre: "el pájaro",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/20-pajaro.jpg",
-        audio: "",
-      },
-      21: {
-        nombre: "la mano",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/21-mano.jpg",
-        audio: "",
-      },
-      22: {
-        nombre: "la bota",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/22-bota.jpg",
-        audio: "",
-      },
-      23: {
-        nombre: "la luna",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/23-luna.jpg",
-        audio: "",
-      },
-      24: {
-        nombre: "el cotorro",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/24-cotorro.jpg",
-        audio: "",
-      },
-      25: {
-        nombre: "el borracho",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/25-borracho.jpg",
-        audio: "",
-      },
-      26: {
-        nombre: "el negrito",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/26-negrito.jpg",
-        audio: "",
-      },
-      27: {
-        nombre: "el corazón",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/27-corazon.jpg",
-        audio: "",
-      },
-      28: {
-        nombre: "la sandía",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/28-sandia.jpg",
-        audio: "",
-      },
-      29: {
-        nombre: "el tambor",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/29-tambor.jpg",
-        audio: "",
-      },
-      30: {
-        nombre: "el camarón",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/30-camaron.jpg",
-        audio: "",
-      },
-      31: {
-        nombre: "las jaras",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/31-jaras.jpg",
-        audio: "",
-      },
-      32: {
-        nombre: "el músico",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/32-musico.jpg",
-        audio: "",
-      },
-      33: {
-        nombre: "la araña",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/33-arana.jpg",
-        audio: "",
-      },
-      34: {
-        nombre: "el soldado",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/34-soldado.jpg",
-        audio: "",
-      },
-      35: {
-        nombre: "la estrella",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/35-estrella.jpg",
-        audio: "",
-      },
-      36: {
-        nombre: "el cazo",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/36-cazo.jpg",
-        audio: "",
-      },
-      37: {
-        nombre: "el mundo",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/37-mundo.jpg",
-        audio: "",
-      },
-      38: {
-        nombre: "el apache",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/38-apache.jpg",
-        audio: "",
-      },
-      39: {
-        nombre: "el nopal",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/39-nopal.jpg",
-        audio: "",
-      },
-      40: {
-        nombre: "el alacrán",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/40-alacran.jpg",
-        audio: "",
-      },
-      41: {
-        nombre: "la rosa",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/41-rosa.jpg",
-        audio: "",
-      },
-      42: {
-        nombre: "la calavera",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/42-calavera.jpg",
-        audio: "",
-      },
-      43: {
-        nombre: "la campana",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/43-campana.jpg",
-        audio: "",
-      },
-      44: {
-        nombre: "el cantarito",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/44-cantarito.jpg",
-        audio: "",
-      },
-      45: {
-        nombre: "el venado",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/45-venado.jpg",
-        audio: "",
-      },
-      46: {
-        nombre: "el sol",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/46-sol.jpg",
-        audio: "",
-      },
-      47: {
-        nombre: "la corona",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/47-corona.jpg",
-        audio: "",
-      },
-      48: {
-        nombre: "la chalupa",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/48-chalupa.jpg",
-        audio: "",
-      },
-      49: {
-        nombre: "el pino",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/49-pino.jpg",
-        audio: "",
-      },
-      50: {
-        nombre: "el pescado",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/50-pescado.jpg",
-        audio: "",
-      },
-      51: {
-        nombre: "la palma",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/51-palma.jpg",
-        audio: "",
-      },
-      52: {
-        nombre: "la maceta",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/52-maceta.jpg",
-        audio: "",
-      },
-      53: {
-        nombre: "el arpa",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/53-arpa.jpg",
-        audio: "",
-      },
-      54: {
-        nombre: "la rana",
-        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/54-rana.jpg",
-        audio: "",
-      },
-    },
-  },
   za01: {
     nombre: "Dilla Xhon - Zoogocho",
     botones: {
-      ganar: "!¡lotería",
+      ganar: "!lotería¡",
     },
     cartas: {
       "01": {
@@ -567,6 +289,284 @@ export const barajas = {
         nombre: "ngolh",
         imagen: "https://storage.googleapis.com/loteria-cielo/barajas/dx-zoogocho/57-ngolh.png",
         audio: "/audio/dx-zoogocho/57-ngolh.wav",
+      },
+    },
+  },
+  es01: {
+    nombre: "español de MX",
+    botones: {
+      ganar: "¡lotería!",
+    },
+    cartas: {
+      "01": {
+        nombre: "el gallo",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/01-gallo.jpg",
+        audio: "",
+      },
+      "02": {
+        nombre: "el diablito",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/02-diablito.jpg",
+        audio: "",
+      },
+      "03": {
+        nombre: "la dama",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/03-dama.jpg",
+        audio: "",
+      },
+      "04": {
+        nombre: "el catrín",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/04-catrin.jpg",
+        audio: "",
+      },
+      "05": {
+        nombre: "el paraguas",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/05-paraguas.jpg",
+        audio: "",
+      },
+      "06": {
+        nombre: "la sirena",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/06-sirena.jpg",
+        audio: "",
+      },
+      "07": {
+        nombre: "la escalera",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/07-escalera.jpg",
+        audio: "",
+      },
+      "08": {
+        nombre: "la botella",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/08-botella.jpg",
+        audio: "",
+      },
+      "09": {
+        nombre: "el barril",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/09-barril.jpg",
+        audio: "",
+      },
+      10: {
+        nombre: "el árbol",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/10-arbol.jpg",
+        audio: "",
+      },
+      11: {
+        nombre: "el melón",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/11-melon.jpg",
+        audio: "",
+      },
+      12: {
+        nombre: "el valiente",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/12-valiente.jpg",
+        audio: "",
+      },
+      13: {
+        nombre: "el gorrito",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/13-gorrito.jpg",
+        audio: "",
+      },
+      14: {
+        nombre: "la muerte",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/14-muerte.jpg",
+        audio: "",
+      },
+      15: {
+        nombre: "la pera",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/15-pera.jpg",
+        audio: "",
+      },
+      16: {
+        nombre: "la bandera",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/16-bandera.jpg",
+        audio: "",
+      },
+      17: {
+        nombre: "el bandolón",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/17-bandolon.jpg",
+        audio: "",
+      },
+      18: {
+        nombre: "el violoncello",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/18-violoncello.jpg",
+        audio: "",
+      },
+      19: {
+        nombre: "la garza",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/19-garza.jpg",
+        audio: "",
+      },
+      20: {
+        nombre: "el pájaro",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/20-pajaro.jpg",
+        audio: "",
+      },
+      21: {
+        nombre: "la mano",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/21-mano.jpg",
+        audio: "",
+      },
+      22: {
+        nombre: "la bota",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/22-bota.jpg",
+        audio: "",
+      },
+      23: {
+        nombre: "la luna",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/23-luna.jpg",
+        audio: "",
+      },
+      24: {
+        nombre: "el cotorro",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/24-cotorro.jpg",
+        audio: "",
+      },
+      25: {
+        nombre: "el borracho",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/25-borracho.jpg",
+        audio: "",
+      },
+      // 26: {
+      //   nombre: "el negrito",
+      //   imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/26-negrito.jpg",
+      //   audio: "",
+      // },
+      27: {
+        nombre: "el corazón",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/27-corazon.jpg",
+        audio: "",
+      },
+      28: {
+        nombre: "la sandía",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/28-sandia.jpg",
+        audio: "",
+      },
+      29: {
+        nombre: "el tambor",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/29-tambor.jpg",
+        audio: "",
+      },
+      30: {
+        nombre: "el camarón",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/30-camaron.jpg",
+        audio: "",
+      },
+      31: {
+        nombre: "las jaras",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/31-jaras.jpg",
+        audio: "",
+      },
+      32: {
+        nombre: "el músico",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/32-musico.jpg",
+        audio: "",
+      },
+      33: {
+        nombre: "la araña",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/33-arana.jpg",
+        audio: "",
+      },
+      34: {
+        nombre: "el soldado",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/34-soldado.jpg",
+        audio: "",
+      },
+      35: {
+        nombre: "la estrella",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/35-estrella.jpg",
+        audio: "",
+      },
+      36: {
+        nombre: "el cazo",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/36-cazo.jpg",
+        audio: "",
+      },
+      37: {
+        nombre: "el mundo",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/37-mundo.jpg",
+        audio: "",
+      },
+      // 38: {
+      //   nombre: "el apache",
+      //   imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/38-apache.jpg",
+      //   audio: "",
+      // },
+      39: {
+        nombre: "el nopal",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/39-nopal.jpg",
+        audio: "",
+      },
+      40: {
+        nombre: "el alacrán",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/40-alacran.jpg",
+        audio: "",
+      },
+      41: {
+        nombre: "la rosa",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/41-rosa.jpg",
+        audio: "",
+      },
+      42: {
+        nombre: "la calavera",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/42-calavera.jpg",
+        audio: "",
+      },
+      43: {
+        nombre: "la campana",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/43-campana.jpg",
+        audio: "",
+      },
+      44: {
+        nombre: "el cantarito",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/44-cantarito.jpg",
+        audio: "",
+      },
+      45: {
+        nombre: "el venado",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/45-venado.jpg",
+        audio: "",
+      },
+      46: {
+        nombre: "el sol",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/46-sol.jpg",
+        audio: "",
+      },
+      47: {
+        nombre: "la corona",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/47-corona.jpg",
+        audio: "",
+      },
+      48: {
+        nombre: "la chalupa",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/48-chalupa.jpg",
+        audio: "",
+      },
+      49: {
+        nombre: "el pino",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/49-pino.jpg",
+        audio: "",
+      },
+      50: {
+        nombre: "el pescado",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/50-pescado.jpg",
+        audio: "",
+      },
+      51: {
+        nombre: "la palma",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/51-palma.jpg",
+        audio: "",
+      },
+      52: {
+        nombre: "la maceta",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/52-maceta.jpg",
+        audio: "",
+      },
+      53: {
+        nombre: "el arpa",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/53-arpa.jpg",
+        audio: "",
+      },
+      54: {
+        nombre: "la rana",
+        imagen: "https://storage.googleapis.com/loteria-cielo/barajas/es-mx/54-rana.jpg",
+        audio: "",
       },
     },
   },


### PR DESCRIPTION
I put the Dilla Xhon deck first so it's the default deck when the game loads up. You can still select "español de MX" as a deck (but it's no longer default).

I also removed two of the Don Miguel cards.