### PR TITLE
Fix translation of back button

### DIFF
--- a/src/translations/es/ui.json
+++ b/src/translations/es/ui.json
@@ -19,5 +19,5 @@
   "salaHost": "Cuando todos los jugadores estén listos presione INICIAR",
   "salaPlayer": "El anfitrión comenzará cuando todos los jugadores estén listos",
   "salaCode": "Sala código:",
-  "back": "Regresa"
+  "back": "Regresar"
 }


### PR DESCRIPTION
Fixes https://github.com/JessRudder/loteria-cielo/issues/26

This PR renames the translation of back button from Regresa to Regresar. 

The issue also mentions:
> "!Lotería" winner button on the Dilla Xhon Baraja , the exclamation marks are opposite

The existing translation already has both exclamation marks on both sides

https://github.com/JessRudder/loteria-cielo/blob/bcf2407752fdee6ea1b9053c342e544737b7c5ad/src/translations/es/ui.json#L2