### PR TITLE
Internalization fixes

### DIFF
--- a/src/App/Juego/index.js
+++ b/src/App/Juego/index.js
@@ -18,7 +18,8 @@ const Juego = ({
   ganador,
   playAudio,
   winConditionHeader,
-  winConditionText
+  winConditionText,
+  startText
 }) => (
   <div className="juego">
     <Stack direction="horizontal">
@@ -71,7 +72,7 @@ const Juego = ({
                 />
               </div>
             ) : (
-              <div className="juego-start-header">¡Corre y se va!</div>
+              <div className="juego-start-header">{startText}</div>
             )}
           </div>
           <Button className="loteria" onClick={() => g.verificar()}>

--- a/src/App/index.js
+++ b/src/App/index.js
@@ -246,6 +246,7 @@ const App = () => {
             playAudio={playAudio}
             winConditionHeader={t("winConditionHeader")}
             winConditionText={t("winConditionText")}
+            startText={t("startText")}
           />
         </Route>
         <Route path={`/${gameId}`}>

--- a/src/translations/en/ui.json
+++ b/src/translations/en/ui.json
@@ -8,7 +8,6 @@
   "registrar": "register - in the lobby",
   "iniciar": "start",
   "jugar": "play",
-  "ganar": "winner - the player {{ganador}} won",
   "empate": "tie - no one won",
   "iniciando": "Starting...",
   "hostIniciar": "Start",

--- a/src/translations/en/ui.json
+++ b/src/translations/en/ui.json
@@ -25,5 +25,6 @@
   "home": "Home",
   "otraVez": "Play again",
   "winConditionHeader": "HOW TO WIN",
-  "winConditionText": "Get four cards in a corner or four cards in a horizontal or vertical row."
+  "winConditionText": "Get four cards in a corner or four cards in a horizontal or vertical row.",
+  "startText": "Let's get started!"
 }

--- a/src/translations/es/ui.json
+++ b/src/translations/es/ui.json
@@ -8,7 +8,6 @@
   "registrar": "registrar - en el lobby",
   "iniciar": "iniciar",
   "jugar": "jugar",
-  "ganar": "ganar - ganó el jugador {{ganador}}",
   "empate": "empate - no ganó nadie",
   "iniciando": "Iniciando...",
   "hostIniciar": "Iniciar",

--- a/src/translations/es/ui.json
+++ b/src/translations/es/ui.json
@@ -25,5 +25,6 @@
   "home": "Inicio",
   "otraVez": "Juega de nuevo",
   "winConditionHeader": "CÓMO SE GANA",
-  "winConditionText": "Marca cuatro cartas en un pozo o cuatro cartas en una fila horizontal o vertical."
+  "winConditionText": "Marca cuatro cartas en un pozo o cuatro cartas en una fila horizontal o vertical.",
+  "startText": "¡Corre y se va!"
 }


### PR DESCRIPTION
The translation files contain two entries for "ganar" (lines 11 and 24). Removed the first one, which appears to be unused.
Added localized text for "¡Corre y se va!" (displayed at the start of a new round)