### PR TITLE
Changes start btn copy to "waiting for host" for non host players

### DIFF
--- a/src/App/Sala/index.js
+++ b/src/App/Sala/index.js
@@ -89,7 +89,7 @@ const Sala = ({ g, jugadorId, estatusActual, registrar, iniciar }) => {
                 className="col-4"
                 onClick={leaveLobbyStartGame}
               >
-                {t("hostIniciar")}
+                {g.isHost ? t("hostIniciar") : t("esperandoParaHost")}
               </Button>
             ) : (
               <Button disabled className="col-4">

--- a/src/translations/en/ui.json
+++ b/src/translations/en/ui.json
@@ -16,6 +16,7 @@
   "Conectándose": "Connecting...",
   "imprimir": "Print version",
   "salaHeader": "Waiting for players...",
+  "esperandoParaHost": "Waiting for host...",
   "salaHost": "Send this URL to other players. When all players are ready press START",
   "salaPlayer": "The host can start when all players are ready",
   "salaCode": "URL:",

--- a/src/translations/es/ui.json
+++ b/src/translations/es/ui.json
@@ -16,6 +16,7 @@
   "conectándose": "Conectándose...",
   "imprimir": "Versión impresa",
   "salaHeader": "Esperando jugadores...",
+  "esperandoParaHost": "Esperando para host",
   "salaHost": "Envía esta URL a otros jugadores. Cuando todos los jugadores estén listos presione INICIAR",
   "salaPlayer": "El anfitrión comenzará cuando todos los jugadores estén listos",
   "salaCode": "URL:",


### PR DESCRIPTION
This PR changes start btn copy to "waiting for host" for non host players.

This is to help prevent confusion on why non host players have a greyed out start button.

<img width="820" alt="Screen Shot 2022-10-10 at 1 08 26 PM" src="https://user-images.githubusercontent.com/4443635/194944662-846067f0-a280-40de-8ecd-5766a804e06d.png">

Fixes: https://github.com/JessRudder/loteria-cielo/issues/61