### PR TITLE
Use direct deployment to GitHub Pages instead of branch-based

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,24 +1,56 @@
 name: Build and Deploy
+
 on:
   push:
     branches:
       - main
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages.
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment.
+# Recommended if you intend to make multiple deployments in quick succession.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  build-and-deploy:
-    concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
+  # Build job
+  build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
 
-      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
-        run: |
-          npm ci
-          npm run build
-
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Setup Node ⚙️
+        uses: actions/setup-node@v3
         with:
-          folder: build # The folder the action should deploy.
+          node-version-file: '.node-version'
+          cache: npm
+
+      - name: Install dependencies 🔧
+        run: npm ci
+
+      - name: Build static HTML to export 🔨
+        run: npm run build
+
+      - name: Upload artifact 📦
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./build
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages 🚀
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+  # Allows you to run this workflow manually from the Actions tab.
+  workflow_dispatch:
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages.
 permissions:
   contents: read

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -48,11 +48,12 @@ jobs:
 
   # Deployment job
   deploy:
+    needs: build
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    timeout-minutes: 2
     steps:
       - name: Deploy to GitHub Pages 🚀
         id: deployment

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -17,7 +17,7 @@ permissions:
 # Allow one concurrent deployment.
 # Recommended if you intend to make multiple deployments in quick succession.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: 'pages'
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Building off Gabe's work in PR #79, this PR moves from using branch-based deployments to direct deployments for GitHub Pages. 🚀 

### Background

Since [July](https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/), GitHub Pages has offered the ability to deploy directly from custom Actions workflows instead of requiring users to push their deployable content into a specified branch (e.g. `gh-pages`) or directory within the repository.

For repositories not using Jekyll, this offers a huge increase in the flexibility and freedom of what can easily be deployed to GitHub Pages without the extra acrobatics of clever third-party Actions such as `JamesIves/github-pages-deploy-action@v4`. ❤️ 🤸

### Why?

- This eliminates the need to maintain a separate `gh-pages` branch
- This eliminates the second of the 2 Actions workflows involved in your current deployment strategy:
  1. Explicit: [actions/workflows/build-and-deploy.yml](https://github.com/JessRudder/loteria-cielo/actions/workflows/build-and-deploy.yml)
  2. Implicit: [actions/workflows/pages/pages-build-deployment](https://github.com/JessRudder/loteria-cielo/actions/workflows/pages/pages-build-deployment)
- This should represent a fairly significant drop in overall time to successful deployment:
  - The combined durations of your latest workflow runs (2 workflows ☝🏻), [\[1\]](https://github.com/JessRudder/loteria-cielo/actions/runs/3424422294) + [\[2\]](https://github.com/JessRudder/loteria-cielo/actions/runs/3424433044), totaled up to ~3.5 minutes, plus time spent waiting in the queue between the 2 runs
  - My [latest workflow run](https://github.com/JamesMGreene/loteria-cielo/actions/runs/3535790603) finished in just under 2 minutes
- This positions the project to take advantage of future enhancements to GitHub Pages, such as **_eventual_** PR preview deployment capabilities ⏳ 

### Demo

Using this deployment workflow for my fork, you can see it currently hosted on GitHub Pages:
- https://jamesmgreene.github.io/loteria-cielo/ 👀 

### TODO

#### Before merging

- [x] Change your Pages deployment mechanism to "GitHub Actions" instead of "Deploy from a branch": [settings/pages](https://github.com/JessRudder/loteria-cielo/settings/pages)
  - Documentation: [Publishing with a custom GitHub Actions workflow](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow)

#### After merging

- [ ] Delete the `gh-pages` branch: [branches/all?query=gh-pages](https://github.com/JessRudder/loteria-cielo/branches/all?query=gh-pages)